### PR TITLE
METL-218: new endpoint ListUsersInRoom, new structure of securityList…

### DIFF
--- a/src/main/scala/com/metl/model/Rooms.scala
+++ b/src/main/scala/com/metl/model/Rooms.scala
@@ -25,7 +25,7 @@ abstract class RoomProvider(configName:String) {
   def get(jid:String,roomMetaData:RoomMetaData,eternal:Boolean):MeTLRoom
   def removeMeTLRoom(room:String):Unit
   def exists(room:String):Boolean
-  def list:List[String]
+  def list:List[MeTLRoom]
 }
 
 object EmptyRoomProvider extends RoomProvider("empty") {
@@ -94,7 +94,7 @@ object RoomMetaDataUtils {
 
 class HistoryCachingRoomProvider(configName:String,idleTimeout:Option[Long]) extends RoomProvider(configName) with Logger {
   protected lazy val metlRooms = new java.util.concurrent.ConcurrentHashMap[String,MeTLRoom]
-  override def list = metlRooms.keys.asScala.toList
+  override def list = metlRooms.values.asScala.toList
   override def exists(room:String):Boolean = Stopwatch.time("Rooms.exists", list.contains(room))
   override def get(room:String,roomDefinition:RoomMetaData,eternal:Boolean) = Stopwatch.time("Rooms.get",metlRooms.computeIfAbsent(room, new java.util.function.Function[String,MeTLRoom]{
     override def apply(r:String) = createNewMeTLRoom(room,roomDefinition,eternal)

--- a/src/main/scala/com/metl/view/Endpoints.scala
+++ b/src/main/scala/com/metl/view/Endpoints.scala
@@ -302,6 +302,7 @@ object MeTLStatefulRestHelper extends RestHelper with Logger {
       }
     })
     case Req(List("listRooms"),_,_) if Globals.isSuperUser => () => Stopwatch.time("MeTLStatefulRestHelper.listRooms",StatelessHtml.listRooms)
+    case Req(List("listUsersInRooms"),_,_) if Globals.isSuperUser => () => Stopwatch.time("MeTLStatefulRestHelper.listRooms",StatelessHtml.listUsersInRooms)
     case Req(List("listSessions"),_,_) if Globals.isSuperUser => () => Stopwatch.time("MeTLStatefulRestHelper.listSessions",StatelessHtml.listSessions)
     case Req(List("conversationExport",conversation),_,_) => () => Stopwatch.time("MeTLStatefulRestHelper.exportConversation",StatelessHtml.exportConversation(Globals.currentUser.is,conversation))
     case Req(List("conversationExportForMe",conversation),_,_) => () => Stopwatch.time("MeTLStatefulRestHelper.exportConversation",StatelessHtml.exportMyConversation(Globals.currentUser.is,conversation))


### PR DESCRIPTION
…ener which should contend less, when server shutsdown, messages emitted to the security log to reflect all users who were online at the time, listSessions now sorts by most recent activity, so that we know how active people are.