### PR TITLE
METL-453: removed the specific behaviours of catching and throwing in…

### DIFF
--- a/src/main/scala/com/metl/comet/MeTL.scala
+++ b/src/main/scala/com/metl/comet/MeTL.scala
@@ -834,20 +834,13 @@ class MeTLActor extends StronglyTypedJsonActor with Logger with JArgUtils with C
     ClientSideFunction("getRooms",List.empty[String],(unused) => JArray(rooms.map(kv => JObject(List(JField("server",JString(kv._1._1)),JField("jid",JString(kv._1._2)),JField("room",JString(kv._2.toString))))).toList),Full("recieveRoomListing")),
     ClientSideFunction("getUser",List.empty[String],(unused) => JString(username),Full(RECEIVE_USERNAME)),
     ClientSideFunction("changePermissionsOfConversation",List("jid","newPermissions"),(args) => {
-      try {
-        val jid = getArgAsString(args(0))
-        val newPermissions = getArgAsJValue(args(1))
-        val c = serverConfig.detailsOfConversation(jid)
-        serializer.fromConversation(shouldModifyConversation(c) match {
-          case true => serverConfig.changePermissions(c.jid.toString,serializer.toPermissions(newPermissions))
-          case _ => c
-        })
-      } catch {
-        case e:Exception => {
-          error("exception while updating permissions: %s".format(args.toString),e)
-          throw e
-        }
-      }
+      val jid = getArgAsString(args(0))
+      val newPermissions = getArgAsJValue(args(1))
+      val c = serverConfig.detailsOfConversation(jid)
+      serializer.fromConversation(shouldModifyConversation(c) match {
+        case true => serverConfig.changePermissions(c.jid.toString,serializer.toPermissions(newPermissions))
+        case _ => c
+      })
     },Full(RECEIVE_CONVERSATION_DETAILS)),
     ClientSideFunction("changeBlacklistOfConversation",List("jid","newBlacklist"),(args) => {
       val jid = getArgAsString(args(0))
@@ -1161,7 +1154,6 @@ class MeTLActor extends StronglyTypedJsonActor with Logger with JArgUtils with C
       ))
     },Full("receiveOrgUnitsFromGroupsProviders")),
     ClientSideFunction("getGroupSetsForOrgUnit",List("storeId","orgUnit"),(args) => {
-      try {
       val sid = getArgAsString(args(0))
       val orgUnitJValue = getArgAsJValue(args(1))
       val orgUnit = orgUnitJValue.extract[OrgUnit]
@@ -1180,12 +1172,6 @@ class MeTLActor extends StronglyTypedJsonActor with Logger with JArgUtils with C
         JField("orgUnit",orgUnitJValue),
         JField("groupSets",groupSets)
       ))
-      } catch {
-        case e:Exception => {
-          error("exception in getGroupSetsForOrgUnit: %s".format(args),e)
-          throw e
-        }
-      }
     },Full("receiveGroupSetsForOrgUnit")),
     ClientSideFunction("getGroupsForGroupSet",List("storeId","orgUnit","groupSet"),(args) => {
       val sid = getArgAsString(args(0))

--- a/src/main/scala/com/metl/utils/StronglyTypedJsonActor.scala
+++ b/src/main/scala/com/metl/utils/StronglyTypedJsonActor.scala
@@ -26,7 +26,7 @@ object JNum{
   }
 }
 
-abstract class StronglyTypedJsonActor extends CometActor with CometListener {
+abstract class StronglyTypedJsonActor extends CometActor with CometListener with Logger {
 	protected val functionDefinitions:List[ClientSideFunction]
   case class ClientSideFunction(val name:String,val args:List[String],val serverSideFunc:List[JValue]=>JValue,val returnResultFunction:Box[String],val returnResponse:Boolean = false,val returnArguments:Boolean = false){
     import net.liftweb.json.Extraction._
@@ -71,7 +71,10 @@ abstract class StronglyTypedJsonActor extends CometActor with CometListener {
                 }
               }
             }
-            case Left(e) => List(JField("error",JString(e.getMessage)))
+            case Left(e) => {
+              error("exception in ClientSideFunc : %s(%s)".format(name,s),e)
+              List(JField("error",JString(e.getMessage)))
+            }
           }
         } ::: List(
           JField("command",JString(name)),


### PR DESCRIPTION
… one or two clientside funcs and generalized the behaviour to all of them so that we get stacktraces when they fail.